### PR TITLE
Add feature flags to configurations

### DIFF
--- a/src/main/scala/codacy/metrics/cachet/CachetConfiguration.scala
+++ b/src/main/scala/codacy/metrics/cachet/CachetConfiguration.scala
@@ -2,14 +2,16 @@ package codacy.metrics.cachet
 
 import play.api.{Configuration, Play}
 
-trait CachetConfiguration extends Any{
+trait CachetConfiguration{
 
   def underlying: Configuration
 
-  def cachetToken   = underlying.getString("codacy.metric.cachet.token")
-  def cachetUrl     = underlying.getString("codacy.metric.cachet.url")
-  def cachetMetrics = underlying.getBoolean("codacy.metric.cachet.metricsEnabled").getOrElse(false)
-  def cachetEnabled = cachetToken.isDefined && cachetUrl.isDefined
+  object cachet{
+    lazy val token   = underlying.getString("codacy.metric.cachet.token").filter(_.nonEmpty)
+    lazy val url     = underlying.getString("codacy.metric.cachet.url").filter(_.nonEmpty)
+    lazy val metrics = underlying.getBoolean("codacy.metric.cachet.metricsEnabled").getOrElse(false)
+    lazy val enabled = underlying.getBoolean("codacy.metric.cachet.isEnabled").getOrElse(false)
+  }
 }
 
 object CachetConfiguration extends CachetConfiguration {

--- a/src/main/scala/codacy/metrics/cachet/WsApi.scala
+++ b/src/main/scala/codacy/metrics/cachet/WsApi.scala
@@ -54,8 +54,8 @@ private[cachet] trait WsApi{
 
   private[this] def applyRequest[P,R](request:Request[P,R],param:P)(implicit ws: WSClient, ctx: ExecutionContext): Future[R] = {
     (for{
-      baseUrl <- CachetConfiguration.cachetUrl
-      token   <- CachetConfiguration.cachetToken
+      baseUrl <- CachetConfiguration.cachet.url
+      token   <- CachetConfiguration.cachet.token
     } yield{
       val fullPath = s"$baseUrl${request.url(param)}"
       request.f(param)(ws.url(fullPath).withHeaders("X-Cachet-Token" -> token)).flatMap(request.mapper)

--- a/src/main/scala/codacy/metrics/cachet/package.scala
+++ b/src/main/scala/codacy/metrics/cachet/package.scala
@@ -4,5 +4,5 @@ import _root_.play.api.Configuration
 
 package object cachet extends Formats with WsApi with Crud with Cruds{
 
-  implicit class ConfigurationExtension(val underlying:Configuration) extends AnyVal with CachetConfiguration
+  implicit class ConfigurationExtension(val underlying:Configuration) extends CachetConfiguration
 }

--- a/src/main/scala/codacy/metrics/play/GraphiteReporter.scala
+++ b/src/main/scala/codacy/metrics/play/GraphiteReporter.scala
@@ -1,0 +1,42 @@
+package codacy.metrics.play
+
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+import codacy.metrics.dropwizard.MetricRegistry
+import com.codahale.metrics.graphite.{Graphite, GraphiteReporter => DropwizardReporter}
+import play.api.Configuration
+import scala.concurrent.duration._
+
+class GraphiteReporter(graphiteKeys:GraphiteConfigKeys, configuration:Configuration){
+
+  private[this] lazy val reporter = {
+    for{
+      hostname <- configuration.graphite.hostname if configuration.graphite.isEnabled
+    } yield {
+
+      val playConfPrefix = configuration.graphite.prefix.map(p => s"$p.").getOrElse("")
+      //then concat the one passed
+      val componentName = graphiteKeys.componentName
+      val instanceName  = graphiteKeys.instanceName
+      val prefix = s"$playConfPrefix$componentName.$instanceName"
+
+      val graphite = new Graphite(new InetSocketAddress(hostname, configuration.graphite.port))
+
+      DropwizardReporter
+        .forRegistry(MetricRegistry)
+        .convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .prefixedWith( prefix ).build(graphite)
+    }
+  }
+
+  def start():Unit = start(1.minute)
+
+  def start(interval:Duration): Unit = {
+    reporter.map(_.start(interval.toMillis,TimeUnit.MILLISECONDS))
+    //TODO: do some logging in case it's not properly configured
+  }
+
+  def stop() = reporter.foreach(_.stop())
+}

--- a/src/main/scala/codacy/metrics/play/MetricConfiguration.scala
+++ b/src/main/scala/codacy/metrics/play/MetricConfiguration.scala
@@ -1,7 +1,7 @@
 package codacy.metrics.play
 
 import codacy.metrics.dropwizard._
-import play.api.{Configuration, Play}
+import play.api.{Logger, Configuration, Play}
 
 trait MetricConfiguration{
 
@@ -10,13 +10,36 @@ trait MetricConfiguration{
   lazy val metricsPath      = underlying.getString("codacy.metric.paths.metrics").getOrElse("/metrics")
   lazy val healthPath       = underlying.getString("codacy.metric.paths.health" ).getOrElse("/health")
   lazy val databaseMetrics  = underlying.getBoolean("codacy.metric.dbMetricsEnabled").getOrElse(false)
-  lazy val graphiteHostname = underlying.getString("codacy.metric.graphiteHostname")
-  lazy val graphitePort     = underlying.getInt("codacy.metric.graphitePort").getOrElse(2003)
-  lazy val graphitePrefix   = underlying.getString("codacy.metric.graphitePrefix")
+
+  object graphite{
+    lazy val isEnabled = underlying.getBoolean("codacy.metric.graphite.isEnabled").getOrElse(false)
+    lazy val hostname  = withDeprecatedString("codacy.metric.graphite.hostname","codacy.metric.graphiteHostname")
+    lazy val port      = withDeprecatedInt("codacy.metric.graphite.port","codacy.metric.graphitePort").getOrElse(2003)
+    lazy val prefix    = withDeprecatedString("codacy.metric.graphite.prefix","codacy.metric.graphitePrefix")
+  }
 
   lazy val requests           = MeterName(/*config.getString("metric.meters.requests").getOrElse(*/"requests")//)
   lazy val successfulRequests = MeterName(/*config.getString("metric.meters.successfulRequests").getOrElse(*/"successfulRequests")//)
   lazy val failedRequests     = MeterName(/*config.getString("metric.meters.failedRequests").getOrElse(*/"failedRequests")//)
+
+  private[this] def withDeprecatedString(key:String, fallbackKey:String, acceptEmpty:Boolean=false) = {
+    val value = underlying.getString(key).orElse(
+      underlying.getString(fallbackKey).map{ case oldKey =>
+        Logger.warn(s"key: $fallbackKey is deprecated, use $key instead")
+        oldKey
+      }
+    )
+    if (acceptEmpty) value else value.filter(_.nonEmpty)
+  }
+
+  private[this] def withDeprecatedInt(key:String, fallbackKey:String) = {
+    underlying.getInt(key).orElse(
+      underlying.getInt(fallbackKey).map{ case oldKey =>
+        Logger.warn(s"key: $fallbackKey is deprecated, use $key instead")
+        oldKey
+      }
+    )
+  }
 }
 
 object MetricConfiguration extends MetricConfiguration {


### PR DESCRIPTION
also: deprecate graphite keys in favour of a sub-path for cachet

Necessary changes to configs: 
 codacy.metric.cachet.isEnabled=Boolean
 codacy.metric.graphite.isEnabled=Boolean
(they default to false!)

Optional changes - change the following keys to their new name:
  codacy.metric.graphiteHostname -> codacy.metric.graphite.hostname 
  codacy.metric.graphitePort           -> codacy.metric.graphite.port
  codacy.metric.graphitePrefix        -> codacy.metric.graphite.prefix

A deprecation warning will be logged if you don't change the keys 
