### PR TITLE
Error handler fix alternative

### DIFF
--- a/src/main/scala/codacy/metrics/play/MetricErrorHandler.scala
+++ b/src/main/scala/codacy/metrics/play/MetricErrorHandler.scala
@@ -1,6 +1,8 @@
 package codacy.metrics.play
 
+import codacy.metrics.dropwizard.mark
 import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc._
 import play.api.routing.Router
 import play.api.{Configuration, Environment}
 import play.core.SourceMapper
@@ -11,18 +13,25 @@ import scala.concurrent.Future
 class MetricErrorHandler(environment: Environment,
                          configuration: Configuration,
                          sourceMapper: Option[SourceMapper] = None,
-                         router: => Option[Router] = None) extends DefaultHttpErrorHandler(environment,configuration,sourceMapper,router){
-  import play.api.mvc._
-  import codacy.metrics.dropwizard.{Result => _, _}
+                         router: => Option[Router] = None)
+  extends DefaultHttpErrorHandler(environment, configuration, sourceMapper, router) {
 
-  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
-    if(! excludeRequest(request)) mark(configuration.failedRequests)
-    super.onClientError(request,statusCode,message)
+  final override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    if (!excludeRequest(request)) mark(configuration.failedRequests)
+    onClientErrorImpl(request, statusCode, message)
   }
 
-  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
-    if(! excludeRequest(request)) mark(configuration.failedRequests)
-    super.onServerError(request,exception)
+  def onClientErrorImpl(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    super.onClientError(request, statusCode)
   }
+
+  final override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+    if (!excludeRequest(request)) mark(configuration.failedRequests)
+    onServerErrorImpl(request, exception)
+  }
+
+  def onServerErrorImpl(request: RequestHeader, exception: Throwable): Future[Result] = {
+    super.onServerError(request, exception)
+  }
+
 }
-


### PR DESCRIPTION
Machado suggested this alternative, to avoid the composition of HttpErrorHandlers.
This way we protected the override and we still allow adding more logic.
